### PR TITLE
Forward E-mail Descriptions

### DIFF
--- a/src/context/applicationContext.go
+++ b/src/context/applicationContext.go
@@ -14,3 +14,7 @@ func(appContext ApplicationContext) Bind(bindFunction interface{}) {
 func(appContext ApplicationContext) Resolve(toResolve interface{}) {
 	container.Make(toResolve)
 }
+
+func(appContext ApplicationContext) Reset() {
+	container.Reset()
+}

--- a/src/controllers/concealEmail/concealEmail.go
+++ b/src/controllers/concealEmail/concealEmail.go
@@ -5,6 +5,7 @@ import (
 	"github.com/halprin/email-conceal/src/context"
 	"github.com/halprin/email-conceal/src/entities"
 	"github.com/halprin/email-conceal/src/external/lib/errors"
+	"github.com/halprin/email-conceal/src/usecases"
 	"github.com/halprin/email-conceal/src/usecases/concealEmail"
 	"log"
 	"net/http"
@@ -132,7 +133,7 @@ func (receiver ConcealEmailController) Update(arguments map[string]interface{}) 
 			"error": errorString,
 		}
 		return http.StatusBadRequest, jsonMap
-	} else if errors.As(err, &concealEmail.ConcealEmailNotExistError{}) {
+	} else if errors.As(err, &usecases.ConcealEmailNotExistError{}) {
 		errorString := err.Error()
 		log.Printf(errorString)
 		jsonMap := map[string]string{

--- a/src/controllers/concealEmail/concealEmail_test.go
+++ b/src/controllers/concealEmail/concealEmail_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/halprin/email-conceal/src/context"
 	"github.com/halprin/email-conceal/src/entities"
 	"github.com/halprin/email-conceal/src/external/lib/errors"
+	"github.com/halprin/email-conceal/src/usecases"
 	"github.com/halprin/email-conceal/src/usecases/concealEmail"
 	"net/http"
 	"testing"
@@ -326,7 +327,7 @@ func TestUpdateFailedWithConcealEmailNotExist(t *testing.T) {
 	conceaEmailId := "an ID"
 	testAppContext.Bind(func() concealEmail.ConcealEmailUsecase {
 		return &TestConcealEmailUsecase{
-			DeleteDescriptionReturnError: concealEmail.ConcealEmailNotExistError{
+			DeleteDescriptionReturnError: usecases.ConcealEmailNotExistError{
 				ConcealEmailId: conceaEmailId,
 			},
 		}

--- a/src/gateways/dynamodb/configurationDynamo.go
+++ b/src/gateways/dynamodb/configurationDynamo.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
 	"github.com/halprin/email-conceal/src/context"
 	"github.com/halprin/email-conceal/src/external/lib/errors"
-	"github.com/halprin/email-conceal/src/usecases/concealEmail"
+	"github.com/halprin/email-conceal/src/usecases"
 	"log"
 	"strings"
 )
@@ -108,7 +108,7 @@ func (receiver DynamoDbGateway) UpdateConcealedEmail(concealPrefix string, descr
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to get conceal e-mail %s to update it", concealPrefix))
 	} else if item == nil {
-		return concealEmail.ConcealEmailNotExistError{
+		return usecases.ConcealEmailNotExistError{
 			ConcealEmailId: concealPrefix,
 		}
 	}
@@ -160,7 +160,7 @@ func (receiver DynamoDbGateway) GetRealEmailAddressForConcealPrefix(concealPrefi
 	concealEmailKey := generateConcealEmailKey(concealPrefix)
 	concealEmailEntity, err := getItemAsConcealEmailEntity(concealEmailKey, concealEmailKey, tableName)
 	if err != nil {
-		return "", nil, concealEmail.ConcealEmailNotExistError{
+		return "", nil, usecases.ConcealEmailNotExistError{
 			ConcealEmailId: concealPrefix,
 		}
 	}

--- a/src/gateways/dynamodb/helperFunctions.go
+++ b/src/gateways/dynamodb/helperFunctions.go
@@ -84,6 +84,21 @@ func getItem(hashKey string, sortKey string, tableName string) (map[string]*dyna
 	return getOutput.Item, nil
 }
 
+func getItemAsConcealEmailEntity(hashKey string, sortKey string, tableName string) (ConcealEmailEntity, error) {
+	rawItem, err := getItem(hashKey, sortKey, tableName)
+	if err != nil {
+		return ConcealEmailEntity{}, err
+	}
+
+	var concealEmailEntity ConcealEmailEntity
+	err = dynamodbattribute.UnmarshalMap(rawItem, &concealEmailEntity)
+	if err != nil {
+		return ConcealEmailEntity{}, err
+	}
+
+	return concealEmailEntity, nil
+}
+
 func batchWriteItemsWithRollback(structsToWrite []interface{}, rollbackFunction func()) error {
 	log.Println("Batch writing items")
 	return batchInternal(structsToWrite, rollbackFunction, batchWrite)

--- a/src/usecases/concealEmail/concealEmail.go
+++ b/src/usecases/concealEmail/concealEmail.go
@@ -17,14 +17,6 @@ type ConcealEmailUsecase interface {
 	DeleteDescriptionFromExistingEmail(concealedEmailPrefix string) error
 }
 
-type ConcealEmailNotExistError struct {
-	ConcealEmailId string
-}
-
-func (c ConcealEmailNotExistError) Error() string {
-	return fmt.Sprintf("The conceal e-mail %s doesn't exist", c.ConcealEmailId)
-}
-
 type ConcealEmailUsecaseImpl struct {}
 
 func (receiver ConcealEmailUsecaseImpl) Add(sourceEmail string, description *string) (string, error) {

--- a/src/usecases/errors.go
+++ b/src/usecases/errors.go
@@ -1,0 +1,11 @@
+package usecases
+
+import "fmt"
+
+type ConcealEmailNotExistError struct {
+	ConcealEmailId string
+}
+
+func (c ConcealEmailNotExistError) Error() string {
+	return fmt.Sprintf("The conceal e-mail %s doesn't exist", c.ConcealEmailId)
+}

--- a/src/usecases/forwardEmail/forwardEmail.go
+++ b/src/usecases/forwardEmail/forwardEmail.go
@@ -18,7 +18,7 @@ type ForwardEmailUsecase interface {
 
 type ForwardEmailUsecaseImpl struct {}
 
-type EmailAndDescriptionTuple struct {
+type emailAndDescriptionTuple struct {
 	Email       string
 	Description *string
 }
@@ -78,7 +78,7 @@ func (receiver ForwardEmailUsecaseImpl) ForwardEmail(url string) error {
 	return nil
 }
 
-func getActualEmailsFromRecipients(concealToActualRecipients map[string]EmailAndDescriptionTuple) []string {
+func getActualEmailsFromRecipients(concealToActualRecipients map[string]emailAndDescriptionTuple) []string {
 	keys := make([]string, len(concealToActualRecipients))
 
 	index := 0
@@ -90,9 +90,9 @@ func getActualEmailsFromRecipients(concealToActualRecipients map[string]EmailAnd
 	return keys
 }
 
-func getActualRecipients(concealedRecipients []string, domain string) map[string]EmailAndDescriptionTuple {
+func getActualRecipients(concealedRecipients []string, domain string) map[string]emailAndDescriptionTuple {
 	//a map of a conceal recipient to (a tuple of the actual email and description)
-	recipientsAndDescriptions := map[string]EmailAndDescriptionTuple{}
+	recipientsAndDescriptions := map[string]emailAndDescriptionTuple{}
 
 	var configurationGateway ConfigurationGateway
 	applicationContext.Resolve(&configurationGateway)
@@ -108,7 +108,7 @@ func getActualRecipients(concealedRecipients []string, domain string) map[string
 			continue
 		}
 
-		recipientsAndDescriptions[concealedRecipient] = EmailAndDescriptionTuple{
+		recipientsAndDescriptions[concealedRecipient] = emailAndDescriptionTuple{
 			Email:       actualRecipient,
 			Description: description,
 		}
@@ -137,7 +137,7 @@ func emailFromRawBytes(rawEmail []byte) (*mail.Message, error) {
 	return mail.ReadMessage(bytes.NewReader(rawEmail))
 }
 
-func changeHeadersInEmail(email *mail.Message, concealToActualRecipients map[string]EmailAndDescriptionTuple) {
+func changeHeadersInEmail(email *mail.Message, concealToActualRecipients map[string]emailAndDescriptionTuple) {
 	delete(email.Header, "Dkim-Signature")  //the signature is handled by the forwarding service, not us
 	delete(email.Header, "Return-Path")  //don't continue on the return path, especially because it's probably not from a verified domain
 

--- a/src/usecases/forwardEmail/forwardEmail.go
+++ b/src/usecases/forwardEmail/forwardEmail.go
@@ -112,7 +112,6 @@ func getActualRecipients(concealedRecipients []string, domain string) map[string
 			Email:       actualRecipient,
 			Description: description,
 		}
-		//recipientsAndDescriptions = append(recipientsAndDescriptions, actualRecipient)
 	}
 
 	return recipientsAndDescriptions

--- a/src/usecases/forwardEmail/forwardEmail.go
+++ b/src/usecases/forwardEmail/forwardEmail.go
@@ -82,7 +82,7 @@ func getActualRecipients(concealedRecipients []string, domain string) []string {
 	for _, concealedRecipient := range concealedRecipients {
 		concealedRecipientPrefix := strings.TrimSuffix(concealedRecipient, fmt.Sprintf("@%s", domain))
 
-		actualRecipient, err := configurationGateway.GetRealEmailAddressForConcealPrefix(concealedRecipientPrefix)
+		actualRecipient, _, err := configurationGateway.GetRealEmailAddressForConcealPrefix(concealedRecipientPrefix)
 
 		if err != nil {
 			log.Printf("Unable to get actual recipient for concealed recipient %s due to error %+v", concealedRecipient, err)

--- a/src/usecases/forwardEmail/forwardEmail.go
+++ b/src/usecases/forwardEmail/forwardEmail.go
@@ -177,11 +177,13 @@ func changeHeadersInEmail(email *mail.Message, concealToActualRecipients map[str
 	for index, toRecipient := range toRecipients {
 		toAddress := toRecipient.Address
 		actualAddressAndDescription, exists := concealToActualRecipients[toAddress]
-		if !exists || actualAddressAndDescription.Description == nil {
+		if !exists {
 			continue
 		}
 
-		toRecipient.Name = *actualAddressAndDescription.Description
+		if actualAddressAndDescription.Description != nil {
+			toRecipient.Name = *actualAddressAndDescription.Description
+		}
 
 		newRecipients.WriteString(toRecipient.String())
 		if index != len(toRecipients) - 1 {  //don't write the trailing comma and space if this is the last item

--- a/src/usecases/forwardEmail/forwardEmail.go
+++ b/src/usecases/forwardEmail/forwardEmail.go
@@ -176,10 +176,7 @@ func changeHeadersInEmail(email *mail.Message, concealToActualRecipients map[str
 	var newRecipients strings.Builder
 	for index, toRecipient := range toRecipients {
 		toAddress := toRecipient.Address
-		actualAddressAndDescription, exists := concealToActualRecipients[toAddress]
-		if !exists {
-			continue
-		}
+		actualAddressAndDescription := concealToActualRecipients[toAddress]
 
 		if actualAddressAndDescription.Description != nil {
 			toRecipient.Name = *actualAddressAndDescription.Description

--- a/src/usecases/forwardEmail/forwardEmail.go
+++ b/src/usecases/forwardEmail/forwardEmail.go
@@ -18,6 +18,11 @@ type ForwardEmailUsecase interface {
 
 type ForwardEmailUsecaseImpl struct {}
 
+type EmailAndDescriptionTuple struct {
+	Email       string
+	Description *string
+}
+
 func (receiver ForwardEmailUsecaseImpl) ForwardEmail(url string) error {
 	//TODO: I may be copying `rawEmail` around, which could be 150 MB or whatever size big of an e-mail.  That would be bad.
 	//But maybe not?  I believe I may be passing around a "slice", which internally is a pointer?
@@ -46,15 +51,15 @@ func (receiver ForwardEmailUsecaseImpl) ForwardEmail(url string) error {
 	concealedRecipients := getConcealedRecipients(email, domain)
 	log.Printf("Concealed recipients are %s", concealedRecipients)
 	log.Println("Looking up actual recipients...")
-	actualRecipients := getActualRecipients(concealedRecipients, domain)
-	log.Printf("Actual recipients are %s", actualRecipients)
-	if len(actualRecipients) == 0 {
+	concealToActualRecipients := getActualRecipients(concealedRecipients, domain)
+	log.Println("Actual recipients are", concealToActualRecipients)
+	if len(concealToActualRecipients) == 0 {
 		log.Println("No actual recipients to forward e-mail to")
 		return nil
 	}
 
 	log.Println("Changing the headers in e-mail")
-	changeHeadersInEmail(email)
+	changeHeadersInEmail(email, concealToActualRecipients)
 
 	log.Println("Reconstruct raw e-mail bytes")
 	myTypeEmail := ByteSliceMessage(*email)
@@ -63,8 +68,8 @@ func (receiver ForwardEmailUsecaseImpl) ForwardEmail(url string) error {
 	log.Println("Sending the e-mail")
 	var emailSenderGateway SendEmailGateway
 	applicationContext.Resolve(&emailSenderGateway)
-
-	err = emailSenderGateway.SendEmail(modifiedRawEmail, actualRecipients)
+	actualRecipientsEmail := getActualEmailsFromRecipients(concealToActualRecipients)
+	err = emailSenderGateway.SendEmail(modifiedRawEmail, actualRecipientsEmail)
 	if err != nil {
 		log.Printf("Sending the e-mail failed, %+v\n", err)
 		return NewUnableToSendEmailError(err)
@@ -73,8 +78,21 @@ func (receiver ForwardEmailUsecaseImpl) ForwardEmail(url string) error {
 	return nil
 }
 
-func getActualRecipients(concealedRecipients []string, domain string) []string {
-	recipientsStrings := make([]string, 0, len(concealedRecipients))
+func getActualEmailsFromRecipients(concealToActualRecipients map[string]EmailAndDescriptionTuple) []string {
+	keys := make([]string, len(concealToActualRecipients))
+
+	index := 0
+	for key := range concealToActualRecipients {
+		keys[index] = concealToActualRecipients[key].Email
+		index++
+	}
+
+	return keys
+}
+
+func getActualRecipients(concealedRecipients []string, domain string) map[string]EmailAndDescriptionTuple {
+	//a map of a conceal recipient to (a tuple of the actual email and description)
+	recipientsAndDescriptions := map[string]EmailAndDescriptionTuple{}
 
 	var configurationGateway ConfigurationGateway
 	applicationContext.Resolve(&configurationGateway)
@@ -82,7 +100,7 @@ func getActualRecipients(concealedRecipients []string, domain string) []string {
 	for _, concealedRecipient := range concealedRecipients {
 		concealedRecipientPrefix := strings.TrimSuffix(concealedRecipient, fmt.Sprintf("@%s", domain))
 
-		actualRecipient, _, err := configurationGateway.GetRealEmailAddressForConcealPrefix(concealedRecipientPrefix)
+		actualRecipient, description, err := configurationGateway.GetRealEmailAddressForConcealPrefix(concealedRecipientPrefix)
 
 		if err != nil {
 			log.Printf("Unable to get actual recipient for concealed recipient %s due to error %+v", concealedRecipient, err)
@@ -90,10 +108,14 @@ func getActualRecipients(concealedRecipients []string, domain string) []string {
 			continue
 		}
 
-		recipientsStrings = append(recipientsStrings, actualRecipient)
+		recipientsAndDescriptions[concealedRecipient] = EmailAndDescriptionTuple{
+			Email:       actualRecipient,
+			Description: description,
+		}
+		//recipientsAndDescriptions = append(recipientsAndDescriptions, actualRecipient)
 	}
 
-	return recipientsStrings
+	return recipientsAndDescriptions
 }
 
 func getConcealedRecipients(email *mail.Message, domain string) []string {
@@ -115,7 +137,7 @@ func emailFromRawBytes(rawEmail []byte) (*mail.Message, error) {
 	return mail.ReadMessage(bytes.NewReader(rawEmail))
 }
 
-func changeHeadersInEmail(email *mail.Message) {
+func changeHeadersInEmail(email *mail.Message, concealToActualRecipients map[string]EmailAndDescriptionTuple) {
 	delete(email.Header, "Dkim-Signature")  //the signature is handled by the forwarding service, not us
 	delete(email.Header, "Return-Path")  //don't continue on the return path, especially because it's probably not from a verified domain
 
@@ -149,6 +171,26 @@ func changeHeadersInEmail(email *mail.Message) {
 	}
 	email.Header["From"] = []string{newFrom.String()}
 	email.Header["Reply-To"] = []string{originalFromString}
+
+	//add the descriptions to the concealed e-mails in the To header
+	toRecipients, _ := email.Header.AddressList("To")
+	var newRecipients strings.Builder
+	for index, toRecipient := range toRecipients {
+		toAddress := toRecipient.Address
+		actualAddressAndDescription, exists := concealToActualRecipients[toAddress]
+		if !exists || actualAddressAndDescription.Description == nil {
+			continue
+		}
+
+		toRecipient.Name = *actualAddressAndDescription.Description
+
+		newRecipients.WriteString(toRecipient.String())
+		if index != len(toRecipients) - 1 {  //don't write the trailing comma and space if this is the last item
+			newRecipients.WriteString(", ")
+		}
+	}
+
+	email.Header["To"] = []string{newRecipients.String()}
 }
 
 func fromAddressOf(email *mail.Message) *mail.Address {

--- a/src/usecases/forwardEmail/forwardEmail_test.go
+++ b/src/usecases/forwardEmail/forwardEmail_test.go
@@ -663,17 +663,24 @@ func TestForwardEmailUsecaseThatCorrectlyUsesDescription(t *testing.T) {
 
 	knownConcealedEmail := "known@apple.com"
 	knownConcealedEmail2 := "known2@apple.com"
+	knownConcealedEmail3 := "known3@apple.com"
+
+	knownConcealedDescription3 := "To the moon"
+
 	actualEmail1 := "moof@dogcow.com"
 	actualDescription1 := "The coolest description"
+
 	actualEmail2 := "halprin@dogcow.com"
 	actualDescription2 := "Kaboom"
 
-	email := fmt.Sprintf(`To: %s, %s
+	actualEmail3 := "george@dogcow.com"
+
+	email := fmt.Sprintf(`To: %s, %s, %s <%s>
 From: moof@apple.com
 Subject: lol
 
 This is the coolest e-mail ever
-`, knownConcealedEmail, knownConcealedEmail2)
+`, knownConcealedEmail, knownConcealedEmail2, knownConcealedDescription3, knownConcealedEmail3)
 
 	testReadEmailGateway := TestReadEmailGateway{
 		ReadEmailReturnByte: []byte(email),
@@ -691,6 +698,7 @@ This is the coolest e-mail ever
 		GetRealEmailReturn: map[string][]*string{
 			"known": {&actualEmail1, &actualDescription1},
 			"known2": {&actualEmail2, &actualDescription2},
+			"known3": {&actualEmail3, nil},
 		},
 	}
 	testAppContext.Bind(func() ConfigurationGateway {
@@ -714,12 +722,18 @@ This is the coolest e-mail ever
 	}
 
 	rawForwardedEmail := testSendEmailGateway.SendEmailEmail
+	rawForwardedEmailString := string(rawForwardedEmail)
+	fmt.Println(rawForwardedEmailString)
 
 	if !bytes.Contains(rawForwardedEmail, []byte(actualDescription1)) {
 		t.Errorf("The actual e-mail recipient's description %s is missing from the e-mail and it should have been there", actualDescription1)
 	}
 
 	if !bytes.Contains(rawForwardedEmail, []byte(actualDescription2)) {
+		t.Errorf("The actual e-mail recipient's description %s is missing from the e-mail and it should have been there", actualDescription2)
+	}
+
+	if !bytes.Contains(rawForwardedEmail, []byte(knownConcealedDescription3)) {
 		t.Errorf("The actual e-mail recipient's description %s is missing from the e-mail and it should have been there", actualDescription2)
 	}
 

--- a/src/usecases/forwardEmail/forwardEmail_test.go
+++ b/src/usecases/forwardEmail/forwardEmail_test.go
@@ -37,15 +37,16 @@ func (testGateway *TestSendEmailGateway) SendEmail(email []byte, recipients []st
 }
 
 type TestConfigurationGateway struct {
-	GetRealEmailConcealPrefix string
-	GetRealEmailReturnString  string
-	GetRealEmailReturnError   error
+	GetRealEmailConcealPrefix     string
+	GetRealEmailReturnString      string
+	GetRealEmailReturnDescription *string
+	GetRealEmailReturnError       error
 }
 
-func (testGateway *TestConfigurationGateway) GetRealEmailAddressForConcealPrefix(concealedRecipientPrefix string) (string, error) {
+func (testGateway *TestConfigurationGateway) GetRealEmailAddressForConcealPrefix(concealedRecipientPrefix string) (string, *string, error) {
 	testGateway.GetRealEmailConcealPrefix = concealedRecipientPrefix
 
-	return testGateway.GetRealEmailReturnString, testGateway.GetRealEmailReturnError
+	return testGateway.GetRealEmailReturnString, testGateway.GetRealEmailReturnDescription, testGateway.GetRealEmailReturnError
 }
 
 type TestEnvironmentGateway struct {

--- a/src/usecases/forwardEmail/forwardEmail_test.go
+++ b/src/usecases/forwardEmail/forwardEmail_test.go
@@ -658,7 +658,7 @@ This is the coolest e-mail ever
 	}
 }
 
-func TestForwardEmailUsecaseThatCorrectlyUsesDescription(t *testing.T) {
+func TestForwardEmailUsecaseThatCorrectlyChangesToHeader(t *testing.T) {
 	resetBaseDependencies()
 
 	knownConcealedEmail := "known@apple.com"
@@ -666,6 +666,8 @@ func TestForwardEmailUsecaseThatCorrectlyUsesDescription(t *testing.T) {
 	knownConcealedEmail3 := "known3@apple.com"
 
 	knownConcealedDescription3 := "To the moon"
+
+	unknownEmail := "sugar@other.com"
 
 	actualEmail1 := "moof@dogcow.com"
 	actualDescription1 := "The coolest description"
@@ -675,12 +677,12 @@ func TestForwardEmailUsecaseThatCorrectlyUsesDescription(t *testing.T) {
 
 	actualEmail3 := "george@dogcow.com"
 
-	email := fmt.Sprintf(`To: %s, %s, %s <%s>
+	email := fmt.Sprintf(`To: %s, %s, %s <%s>, %s
 From: moof@apple.com
 Subject: lol
 
 This is the coolest e-mail ever
-`, knownConcealedEmail, knownConcealedEmail2, knownConcealedDescription3, knownConcealedEmail3)
+`, knownConcealedEmail, knownConcealedEmail2, knownConcealedDescription3, knownConcealedEmail3, unknownEmail)
 
 	testReadEmailGateway := TestReadEmailGateway{
 		ReadEmailReturnByte: []byte(email),
@@ -734,7 +736,11 @@ This is the coolest e-mail ever
 	}
 
 	if !bytes.Contains(rawForwardedEmail, []byte(knownConcealedDescription3)) {
-		t.Errorf("The actual e-mail recipient's description %s is missing from the e-mail and it should have been there", actualDescription2)
+		t.Errorf("The original e-mail recipient's description %s is missing from the e-mail and it should have been there and not replaced", knownConcealedDescription3)
+	}
+
+	if !bytes.Contains(rawForwardedEmail, []byte(unknownEmail)) {
+		t.Errorf("The unknown e-mail %s is missing from the e-mail and it should have been there", unknownEmail)
 	}
 
 	if bytes.Contains(rawForwardedEmail, []byte(", \r\n")) {

--- a/src/usecases/forwardEmail/gatewayInterfaces.go
+++ b/src/usecases/forwardEmail/gatewayInterfaces.go
@@ -9,5 +9,5 @@ type SendEmailGateway interface {
 }
 
 type ConfigurationGateway interface {
-	GetRealEmailAddressForConcealPrefix(concealedRecipientPrefix string) (string, error)
+	GetRealEmailAddressForConcealPrefix(concealedRecipientPrefix string) (string, *string, error)
 }


### PR DESCRIPTION
Towards #18.

- Modifies the e-mail `To` header to specify the description of the concealed e-mail address instead of the original description in the incoming e-mail.  Doesn't mess with the original description if no description was stored.