### PR TITLE
Upgrade Go Version to 1.18

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/halprin/email-conceal/src
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-lambda-go v1.28.0


### PR DESCRIPTION
Upgrade the minimum version of Go to 1.18.